### PR TITLE
Implement authentication, wifi loop, and boot script

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,0 +1,6 @@
+import machine
+try:
+    import logic.main as app
+    app.main()
+except Exception as e:
+    machine.reset()

--- a/portal/index.html
+++ b/portal/index.html
@@ -7,13 +7,14 @@
 	<link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
 	<link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
 	<script>
-		async function authenticateUser() {
-			event.preventDefault();
-			const username = document.getElementById("auth_username_field").value;
-			const password = document.getElementById("auth_password_field").value;
-			const pin = document.getElementById("auth_pin_field").value;
+                async function authenticateUser() {
+                        event.preventDefault();
+                        const username = document.getElementById("auth_username_field").value;
+                        const password = document.getElementById("auth_password_field").value;
+                        const pin = document.getElementById("auth_pin_field").value;
+                        const remember = document.getElementById("rememberMeCheck").checked;
 
-			const payload = JSON.stringify({ username, password, pin });
+                        const payload = JSON.stringify({ username, password, pin, remember });
 
 			try {
 				const response = await fetch("/api/auth", {
@@ -24,12 +25,16 @@
 					body: payload
 				});
 
-				const result = await response.json();
-				if (result.success) {
-					window.location.href = "/overview";
-				} else {
-					alert("Authentication failed: " + result.message);
-				}
+                                const result = await response.json();
+                                if (result.success) {
+                                        if (result.token) {
+                                                const cookie = `session=${result.token}; path=/` + (remember ? '; max-age=604800' : '');
+                                                document.cookie = cookie;
+                                        }
+                                        window.location.href = "/overview";
+                                } else {
+                                        alert("Authentication failed: " + result.message);
+                                }
 			} catch (err) {
 				alert("Error contacting server.");
 				console.error(err);
@@ -37,7 +42,7 @@
 		}
 	</script>
 </head>
-<body>
+<body class="noauth">
 
 <div class="authLogo">
 	<img src="../assets/garden.gif" alt="GardenPi+" class="logoIcon">

--- a/portal/simplelogic.js
+++ b/portal/simplelogic.js
@@ -3,7 +3,14 @@
   and delete the <script src="simplelogic.js"></script> in every file as well. */
 
 
-// Authentication
+// Authentication helper
+function checkSession() {
+  if (!document.body.classList.contains('noauth')) {
+    if (!document.cookie.includes('session=')) {
+      window.location.href = '/';
+    }
+  }
+}
 
 
 // Live Clock
@@ -25,6 +32,7 @@ setInterval(updateClock, 1000);
 window.onload = () => {
   updateClock();
   setupDarkMode();
+  checkSession();
 }
 
 // Dark Mode Toggle
@@ -108,17 +116,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-// Disable Schedule Form Elements w/o Check
-function toggleDay(day) {
-  const checkbox = document.getElementById(`${day}-check`);
-  const timeContainer = document.getElementById(`${day}-times`);
-  const selects = timeContainer.querySelectorAll('select');
-
-  selects.forEach(select => {
-    select.disabled = !checkbox.checked;
-    select.style.opacity = checkbox.checked ? "1" : "0.5";
-  });
-}
 
 // Misting (Automated & Manual) Alert
 function alertBox() {


### PR DESCRIPTION
## Summary
- add helpers for session cookies and persist auth tokens
- support WiFi reconnect loop with backoff
- implement `/api/auth` endpoint with cookie handling
- enforce auth on portal pages using client-side check
- update login page for Remember Me option
- automatically start main application through new `boot.py`
- remove duplicate JS and add newline at EOF

## Testing
- `python3 -m py_compile logic/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6844d2bd5178832b932aa172be59979c