### PR TITLE
Fix schedule timing and add persistent controller logic

### DIFF
--- a/logic/main.py
+++ b/logic/main.py
@@ -426,7 +426,7 @@ def handle_get_version():
 # --------- Schedule Runner ---------
 def run_schedule():
     check_weather()
-    t = time.localtime(time.time() - 14400)  # Adjust for UTC-4
+    t = time.localtime()
     current_min = t[3] * 60 + t[4]
     today = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][t[6]]
 
@@ -478,10 +478,14 @@ def web_server():
     s.bind(addr)
     s.listen(1)
     print("[WEB] Server running at http://" + network.WLAN(network.STA_IF).ifconfig()[0])
+    s.settimeout(1)
 
     while True:
         run_schedule()
-        cl, _ = s.accept()
+        try:
+            cl, _ = s.accept()
+        except OSError:
+            continue
         try:
             req = cl.recv(1024).decode("utf-8")
             if not req:


### PR DESCRIPTION
## Summary
- remove UTC offset from schedule runner
- run schedule even when no clients connect by using a socket timeout
- update controller javascript to fetch and save mist schedule
- send misting state updates to the backend
- remove unused auth.js

## Testing
- `python3 -m py_compile logic/main.py`
- `node -c portal/simplelogic.js`