### PR TITLE
Fix static file auth and UI tweaks

### DIFF
--- a/logic/main.py
+++ b/logic/main.py
@@ -176,6 +176,10 @@ def get_hardware_info():
             info = json.load(f)
     except:
         info = {}
+    try:
+        info["serial"] = machine.unique_id().hex()
+    except Exception:
+        pass
     alloc = gc.mem_alloc()
     free = gc.mem_free()
     info["mem_free"] = free
@@ -556,7 +560,8 @@ def web_server():
                 cl.send(http_json(get_hardware_info()))
 
             else:
-                if path != "/" and not authenticated and not path.startswith("/assets") and path not in ("/manifest.json", "/service-worker.js"):
+                if path != "/" and not authenticated and not path.startswith("/assets") \
+                   and path not in ("/manifest.json", "/service-worker.js", "/styles.css", "/simplelogic.js", "/weather_API.js"):
                     cl.send(b"HTTP/1.1 302 Found\r\nLocation: /\r\n\r\n")
                     continue
                 if path == "/":

--- a/portal/about/index.html
+++ b/portal/about/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
         <script src="../simplelogic.js"></script>
 </head>
@@ -15,7 +15,7 @@
   <div class="navGPiContainer">
     <div class="navLogo">
       <a href="/overview">
-        <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+        <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
       </a>
     </div>
     <div class="navGPi">

--- a/portal/console/index.html
+++ b/portal/console/index.html
@@ -4,7 +4,7 @@
 	<title>GardenPi Portal - Console</title>
 	<meta charset="UTF-8">
         <link rel="stylesheet" href="../styles.css">
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
         <script src="../simplelogic.js"></script>
@@ -15,7 +15,7 @@
   <div class="navGPiContainer">
     <div class="navLogo">
       <a href="/overview">
-        <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+        <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
       </a>
     </div>
     <div class="navGPi">

--- a/portal/controller/index.html
+++ b/portal/controller/index.html
@@ -4,7 +4,7 @@
   <title>GardenPi Portal - Controller</title>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="../styles.css">
-  <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
   <link rel="manifest" href="/manifest.json">
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
   <script src="../simplelogic.js"></script>
@@ -16,7 +16,7 @@
   <div class="navGPiContainer">
     <div class="navLogo">
       <a href="/overview">
-        <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+        <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
       </a>
     </div>
     <div class="navGPi">

--- a/portal/data/index.html
+++ b/portal/data/index.html
@@ -4,7 +4,7 @@
 	<title>GardenPi Portal - Data</title>
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../styles.css">
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
         <script src="../simplelogic.js"></script>
@@ -15,7 +15,7 @@
   <div class="navGPiContainer">
     <div class="navLogo">
       <a href="/overview">
-        <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+        <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
       </a>
     </div>
     <div class="navGPi">

--- a/portal/index.html
+++ b/portal/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="styles.css">
 	<link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
 	<script>
                 async function authenticateUser() {
@@ -46,7 +46,7 @@
 <body class="noauth">
 
 <div class="authLogo">
-	<img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+    <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
 </div>
 
 <div class="authScreenHeaderContainer">

--- a/portal/manifest.json
+++ b/portal/manifest.json
@@ -7,7 +7,7 @@
   "theme_color": "#4caf50",
   "icons": [
     {
-      "src": "/assets/favicon.ico",
+      "src": "https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico",
       "sizes": "48x48 72x72 96x96 128x128",
       "type": "image/x-icon"
     }

--- a/portal/overview/index.html
+++ b/portal/overview/index.html
@@ -4,7 +4,7 @@
 	<title>GardenPi Portal - Overview</title>
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../styles.css">
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
         <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
         <script src="../simplelogic.js"></script>
@@ -15,7 +15,7 @@
   <div class="navGPiContainer">
     <div class="navLogo">
       <a href="/overview">
-        <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+        <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
       </a>
     </div>
     <div class="navGPi">
@@ -89,7 +89,24 @@ async function loadStatus(){
     document.getElementById('mist').textContent = data.mist_active ? 'Running' : 'Idle';
   }
 }
-document.addEventListener('DOMContentLoaded', loadStatus);
+async function loadForecast(){
+  try{
+    const res = await fetch('/api/weather_log');
+    const data = await res.json();
+    const entry = (data.log || []).slice(-1)[0];
+    if(!entry) return;
+    const container = document.querySelector('.dashboardForecastContainer');
+    entry.periods.forEach(p=>{
+      const div = document.createElement('div');
+      div.className = 'forecastDay';
+      div.innerHTML = `<strong>${p.name}</strong><br>${p.temperature}°${p.temperatureUnit}<br>${p.shortForecast}`;
+      container.appendChild(div);
+    });
+  }catch(e){
+    console.error('forecast load failed',e);
+  }
+}
+document.addEventListener('DOMContentLoaded', ()=>{loadStatus(); loadForecast();});
 </script>
 
 </body>

--- a/portal/service-worker.js
+++ b/portal/service-worker.js
@@ -3,7 +3,7 @@ const OFFLINE_URLS = [
   '/',
   '/portal/styles.css',
   '/portal/simplelogic.js',
-  '/assets/favicon.ico'
+  'https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico'
 ];
 
 self.addEventListener('install', event => {

--- a/portal/styles.css
+++ b/portal/styles.css
@@ -300,7 +300,7 @@ body {
   display: grid;
   grid-template-columns: 120px 40px 1fr;
   align-items: center;
-  column-gap: 40px;
+  column-gap: 20px;
   row-gap: 10px;
   margin-bottom: 1.5rem;
 }
@@ -314,9 +314,8 @@ body {
 }
 
 .scheduleRow input[type="checkbox"] {
-  transform: scale(1.5);
+  transform: scale(1.2);
   margin: auto;
-  margin-left: 5.5rem;
   display: block;
   align-self: center;
 }
@@ -324,9 +323,9 @@ body {
 .timeSelectors {
   display: flex;
   flex-wrap: wrap;
-  gap: 15rem;
+  gap: 1rem;
   flex-grow: 1;
-  margin-left: 8.5rem;
+  margin-left: 0;
 }
 
 .timeSlot {

--- a/portal/weather-data/index.html
+++ b/portal/weather-data/index.html
@@ -4,7 +4,7 @@
     <title>GardenPi Portal - Weather</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../styles.css">
-    <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
     <link rel="manifest" href="/manifest.json">
     <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
     <script src="../simplelogic.js"></script>
@@ -15,7 +15,7 @@
         <div class="navGPiContainer">
             <div class="navLogo">
                 <a href="/overview">
-                    <img src="/assets/garden.gif" alt="GardenPi+" class="logoIcon">
+                    <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
                 </a>
             </div>
             <div class="navGPi">


### PR DESCRIPTION
## Summary
- allow styles and scripts without auth for login page
- show device serial in hardware info
- tweak schedule layout in stylesheet
- display last weather forecast on the overview page
- serve favicon and logo directly from GitHub

## Testing
- `python -m py_compile logic/main.py`