### PR TITLE
Improve weather error handling and dark mode

### DIFF
--- a/portal/index.html
+++ b/portal/index.html
@@ -3,11 +3,12 @@
 <head>
 	<title>GardenPi - Login to Your GardenPi+ Portal</title>
 	<meta charset="UTF-8">
-	<link rel="stylesheet" href="styles.css">
-	<link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="styles.css">
+        <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;600;700&display=swap" rel="stylesheet">
         <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/irvingkennet45/GardenPi_Plus/refs/heads/main/assets/favicon.ico">
         <link rel="manifest" href="/manifest.json">
-	<script>
+        <script src="simplelogic.js"></script>
+        <script>
                 async function authenticateUser() {
                         event.preventDefault();
                         const username = document.getElementById("auth_username_field").value;
@@ -47,6 +48,16 @@
 
 <div class="authLogo">
     <img src="https://github.com/irvingkennet45/GardenPi_Plus/blob/main/assets/garden.gif?raw=true" alt="GardenPi+" class="logoIcon">
+</div>
+
+<div class="authNavToggle navToggle">
+    <label class="switch">
+        <input type="checkbox" id="themeToggle">
+        <span class="slider">
+            <span class="icon sun">☀️</span>
+            <span class="icon moon">🌙</span>
+        </span>
+    </label>
 </div>
 
 <div class="authScreenHeaderContainer">

--- a/portal/styles.css
+++ b/portal/styles.css
@@ -519,6 +519,11 @@ label.authForm {
   border-width: 5px;
 }
 
+.authNavToggle {
+  margin-top: 10px;
+  margin-bottom: 20px;
+}
+
 .authFormContainer input {
   outline-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
## Summary
- handle HTTP errors in `fetch_forecast`
- keep the web server running when a client times out
- allow dark mode on the login page
- tweak stylesheet for login page toggle

## Testing
- `python3 -m py_compile logic/main.py`
- `python3 -m py_compile logic/auth_handler.py`
- `python3 -m py_compile logic/action_handler.py`
- `python3 -m py_compile logic/sensor.py`
